### PR TITLE
Fix #19: Empty output with -m option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Features:**
 
+- Add optional reduced memory operation `-m` `--min-memory`
 - Add base log path option: `-b` `--log-base`.
 - Log postfix option: `-p` `--log-postfix`.
 - Auto alias generation: `-a` `--alias-level`.


### PR DESCRIPTION
When one of the log files is empty and we use `-m` option we will get no
output, unlike normal operation that would output contents of all other
files correctly.

This patch fixes this by removing from the files to read empty ones like
we do once we start processing the files.
